### PR TITLE
Deshabilitat la funció insert_crawling_process_error

### DIFF
--- a/massive_importer/lib/db_utils.py
+++ b/massive_importer/lib/db_utils.py
@@ -58,10 +58,6 @@ def delete_events(eventList):
         for event in eventList:
             event.delete()
 
-@db_session
+
 def insert_crawling_process_error(crawler_name, e):
-    CrawlingProcessError(
-        crawler_name=crawler_name,
-        exception_type=str(e.__class__),
-        description=str(e)
-    )
+    raise e


### PR DESCRIPTION
Aquesta funció guarda a la base de dades Postgres el resultat de l'error, però amb el mòdul [som_crawlers](https://github.com/Som-Energia/openerp_som_addons/pull/187) ja no és necessari.